### PR TITLE
feat: add prompt variables support with dynamic variable replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,6 +1137,49 @@ export const agent = new Agent({
 });
 ```
 
+## Prompt Variables
+
+The SDK supports variable parsing in prompts. You can define variables in your prompt using the `{{variable_name}}` syntax and pass values when fetching the prompt.
+
+### Example
+
+```typescript
+// Your prompt template: "Hello {{name}}, welcome to {{platform}}!"
+
+const promptData = await promptrun.prompt({
+  projectId: "your-project-id",
+  variables: {
+    name: "John Doe",
+    platform: "Promptrun",
+  },
+});
+
+console.log(promptData.prompt); // "Hello {{name}}, welcome to {{platform}}!"
+console.log(promptData.processedPrompt); // "Hello John Doe, welcome to Promptrun!"
+```
+
+### Variable Parsing Features
+
+- **Simple replacement**: Variables in `{{variable_name}}` format are replaced with corresponding values
+- **Missing variables**: If a variable is not provided, the original placeholder is preserved
+- **Type conversion**: All variable values are converted to strings
+- **Multiple occurrences**: The same variable can be used multiple times in a prompt
+
+### Example with Missing Variables
+
+```typescript
+const promptData = await promptrun.prompt({
+  projectId: "your-project-id",
+  variables: {
+    name: "John Doe",
+    // 'age' is not provided
+  },
+});
+
+// If prompt is: "Hello {{name}}, your age is {{age}}"
+console.log(promptData.processedPrompt); // "Hello John Doe, your age is {{age}}"
+```
+
 ## Contributing
 
 Contributions are welcome! If you find a bug or have a feature request, please open an issue on our [GitHub repository](https://github.com/Promptrun-ai/promptrun-ai-sdk/issues).

--- a/src/promptrun-polling-prompt.ts
+++ b/src/promptrun-polling-prompt.ts
@@ -98,6 +98,10 @@ export class PromptrunPollingPromptImpl implements PromptrunPollingPrompt {
     return this.currentPrompt.prompt;
   }
 
+  get processedPrompt(): string | undefined {
+    return this.currentPrompt.processedPrompt;
+  }
+
   get version(): number {
     return this.currentPrompt.version;
   }
@@ -574,6 +578,10 @@ export class PromptrunSSEPromptImpl implements PromptrunPollingPrompt {
 
   get prompt(): string {
     return this.currentPrompt.prompt;
+  }
+
+  get processedPrompt(): string | undefined {
+    return this.currentPrompt.processedPrompt;
   }
 
   get version(): number {

--- a/src/promptrun-provider.ts
+++ b/src/promptrun-provider.ts
@@ -4,6 +4,7 @@ import {
   PromptrunPollingPromptImpl,
   PromptrunSSEPromptImpl,
 } from "./promptrun-polling-prompt";
+import { parsePromptVariables } from "./stream-utils";
 import {
   PromptrunAPIError,
   PromptrunAuthenticationError,
@@ -81,6 +82,7 @@ export class PromptrunSDK {
   ): Promise<PromptrunPrompt | PromptrunPollingPrompt> {
     const {
       projectId,
+      variables,
       poll = 6000, // Default to 6000ms polling when not specified
       version,
       tag,
@@ -91,6 +93,14 @@ export class PromptrunSDK {
 
     // Fetch the prompt once
     const initialPrompt = await this.fetchPromptOnce(projectId, version, tag);
+
+    // Process variables if provided
+    if (variables) {
+      initialPrompt.processedPrompt = parsePromptVariables(
+        initialPrompt.prompt,
+        variables
+      );
+    }
 
     // Handle polling logic
     if (poll === "sse") {

--- a/src/stream-utils.ts
+++ b/src/stream-utils.ts
@@ -80,3 +80,24 @@ export function createPromptrunStream(): TransformStream<
     },
   });
 }
+
+/**
+ * Parses and replaces variables in a prompt string.
+ * Variables should be in the format {{variable_name}}.
+ *
+ * @param prompt The prompt string containing variables
+ * @param variables Object containing variable values
+ * @returns The prompt string with variables replaced
+ */
+export function parsePromptVariables(
+  prompt: string,
+  variables: Record<string, string | number | boolean>
+): string {
+  return prompt.replace(/\{\{(\w+)\}\}/g, (match, variableName) => {
+    if (variableName in variables) {
+      return String(variables[variableName]);
+    }
+    // If variable is not found, keep the original placeholder
+    return match;
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,13 @@ export interface PromptrunPromptOptions {
   projectId: string;
 
   /**
+   * Variables to replace in the prompt string.
+   * Variables in the prompt should be in the format {{variable_name}}.
+   * These will be replaced with the corresponding values from this object.
+   */
+  variables?: Record<string, string | number | boolean>;
+
+  /**
    * The polling interval in milliseconds for refetching the prompt.
    * - If omitted, uses default interval of 6000ms (6 seconds).
    * - If set to 0, the prompt will be fetched only once (no polling).
@@ -189,6 +196,8 @@ export interface PromptrunPrompt {
   createdAt: string;
   updatedAt: string;
   prompt: string;
+  /** The processed prompt with variables replaced */
+  processedPrompt?: string;
   version: number;
   versionMessage: string;
   tag: string | null;

--- a/tests/promptrun-provider.test.ts
+++ b/tests/promptrun-provider.test.ts
@@ -348,6 +348,86 @@ describe("Unit Test: PromptrunSDK Provider", () => {
     });
   });
 
+  describe("prompt() method with variables", () => {
+    test("should process variables and add processedPrompt field", async () => {
+      const mockPromptResponse: PromptrunPrompt = {
+        id: "test-id",
+        createdAt: "2023-01-01T00:00:00Z",
+        updatedAt: "2023-01-01T00:00:00Z",
+        prompt: "Hello {{name}}, welcome to {{platform}}!",
+        version: 1,
+        versionMessage: "Initial version",
+        tag: null,
+        temperature: 0.7,
+        user: {
+          id: "user-1",
+          clerkId: "clerk-1",
+        },
+        project: {
+          id: "project-1",
+          name: "Test Project",
+        },
+        model: {
+          name: "Claude",
+          provider: "anthropic",
+          model: "claude-3-sonnet",
+          icon: "claude-icon",
+        },
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockPromptResponse));
+
+      const result = await sdk.prompt({
+        projectId: "test-project",
+        variables: {
+          name: "John Doe",
+          platform: "Promptrun",
+        },
+      });
+
+      expect(result.processedPrompt).toBe(
+        "Hello John Doe, welcome to Promptrun!"
+      );
+      expect(result.prompt).toBe("Hello {{name}}, welcome to {{platform}}!");
+    });
+
+    test("should not add processedPrompt when no variables provided", async () => {
+      const mockPromptResponse: PromptrunPrompt = {
+        id: "test-id",
+        createdAt: "2023-01-01T00:00:00Z",
+        updatedAt: "2023-01-01T00:00:00Z",
+        prompt: "Hello {{name}}, welcome to {{platform}}!",
+        version: 1,
+        versionMessage: "Initial version",
+        tag: null,
+        temperature: 0.7,
+        user: {
+          id: "user-1",
+          clerkId: "clerk-1",
+        },
+        project: {
+          id: "project-1",
+          name: "Test Project",
+        },
+        model: {
+          name: "Claude",
+          provider: "anthropic",
+          model: "claude-3-sonnet",
+          icon: "claude-icon",
+        },
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockPromptResponse));
+
+      const result = await sdk.prompt({
+        projectId: "test-project",
+      });
+
+      expect(result.processedPrompt).toBeUndefined();
+      expect(result.prompt).toBe("Hello {{name}}, welcome to {{platform}}!");
+    });
+  });
+
   describe("Polling functionality - demonstrates the issue", () => {
     test("NEW: should return a polling prompt that provides access to updated data", async () => {
       const sdk = new PromptrunSDK({ apiKey: "test-key" });

--- a/tests/stream-utils.test.ts
+++ b/tests/stream-utils.test.ts
@@ -1,5 +1,8 @@
 import { LanguageModelV1StreamPart } from "@ai-sdk/provider";
-import { createPromptrunStream } from "../src/stream-utils";
+import {
+  createPromptrunStream,
+  parsePromptVariables,
+} from "../src/stream-utils";
 
 /**
  * A type-safe helper function to consume a ReadableStream and return its chunks as an array.
@@ -185,5 +188,68 @@ describe("Unit Test: createPromptrunStream", () => {
       finishReason: "stop",
       usage: { promptTokens: 0, completionTokens: 0 },
     });
+  });
+});
+
+describe("parsePromptVariables", () => {
+  test("should replace variables with provided values", () => {
+    const prompt = "Hello {{name}}, welcome to {{platform}}!";
+    const variables = {
+      name: "John Doe",
+      platform: "Promptrun",
+    };
+
+    const result = parsePromptVariables(prompt, variables);
+    expect(result).toBe("Hello John Doe, welcome to Promptrun!");
+  });
+
+  test("should keep original placeholders for missing variables", () => {
+    const prompt = "Hello {{name}}, your age is {{age}}";
+    const variables = {
+      name: "John Doe",
+    };
+
+    const result = parsePromptVariables(prompt, variables);
+    expect(result).toBe("Hello John Doe, your age is {{age}}");
+  });
+
+  test("should handle empty variables object", () => {
+    const prompt = "Hello {{name}}, welcome to {{platform}}!";
+    const variables = {};
+
+    const result = parsePromptVariables(prompt, variables);
+    expect(result).toBe("Hello {{name}}, welcome to {{platform}}!");
+  });
+
+  test("should handle prompt with no variables", () => {
+    const prompt = "Hello, this is a simple prompt without variables.";
+    const variables = {
+      name: "John Doe",
+    };
+
+    const result = parsePromptVariables(prompt, variables);
+    expect(result).toBe("Hello, this is a simple prompt without variables.");
+  });
+
+  test("should convert variable values to strings", () => {
+    const prompt = "Count: {{count}}, Active: {{active}}";
+    const variables = {
+      count: 42,
+      active: true,
+    };
+
+    const result = parsePromptVariables(prompt, variables);
+    expect(result).toBe("Count: 42, Active: true");
+  });
+
+  test("should handle multiple occurrences of the same variable", () => {
+    const prompt = "{{greeting}} {{name}}! How are you, {{name}}?";
+    const variables = {
+      greeting: "Hello",
+      name: "John",
+    };
+
+    const result = parsePromptVariables(prompt, variables);
+    expect(result).toBe("Hello John! How are you, John?");
   });
 });


### PR DESCRIPTION
- Add parsePromptVariables function to replace {{variable_name}} placeholders
- Extend PromptrunPromptOptions interface with optional variables parameter
- Add processedPrompt field to PromptrunPrompt interface for variable-substituted content
- Update PromptrunSDK.prompt() method to process variables when provided
- Add processedPrompt getter to polling prompt implementations
- Add comprehensive test coverage for variable parsing functionality
- Update README with detailed documentation and examples for prompt variables
- Support string, number, and boolean variable types with automatic conversion
- Preserve original placeholders for missing variables
- Handle multiple occurrences of the same variable in prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using variables in prompt templates, allowing placeholders like {{variable_name}} to be replaced with user-supplied values.
  * Introduced a new processed prompt field that shows the prompt with variables substituted.

* **Documentation**
  * Updated the README with instructions and examples for using prompt variables.

* **Tests**
  * Added tests to verify correct variable substitution and prompt processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->